### PR TITLE
fix dune.include dest

### DIFF
--- a/scripts/before-build.sh
+++ b/scripts/before-build.sh
@@ -3,11 +3,11 @@
 unameOut="$(uname -s)"
 case "${unameOut}" in
     Darwin*)
-        echo '"-framework CoreFoundation -framework Security"' > src/freeton_ocaml_sdk/dune.include
+        echo '"-framework CoreFoundation -framework Security"' > src/freeton_ocaml_rust/dune.include
         echo MacOSX Detected
         ;;
     *)
-        echo '""' > src/freeton_ocaml_sdk/dune.include
+        echo '""' > src/freeton_ocaml_rust/dune.include
         echo MacOSX Not Detected
         ;;
 esac


### PR DESCRIPTION
The script should generate dune.include inside freeton_ocaml_rust folder. 